### PR TITLE
Fix: bringWindowToFront doesn't work on a minimized window

### DIFF
--- a/lib/src/windows_single_instance.dart
+++ b/lib/src/windows_single_instance.dart
@@ -161,6 +161,6 @@ class WindowsSingleInstance {
     SetFocus(mhWnd);
     SetActiveWindow(mhWnd);
     AttachThreadInput(dwCurID, dwMyID, FALSE);
-    ShowWindow(mhWnd, SW_SHOW);
+    if (!identical(0, IsIconic(mhWnd))) ShowWindow(mhWnd, SW_RESTORE);
   }
 }

--- a/lib/src/windows_single_instance.dart
+++ b/lib/src/windows_single_instance.dart
@@ -161,6 +161,6 @@ class WindowsSingleInstance {
     SetFocus(mhWnd);
     SetActiveWindow(mhWnd);
     AttachThreadInput(dwCurID, dwMyID, FALSE);
-    ShowWindow(mhWnd, SW_RESTORE);
+    ShowWindow(mhWnd, SW_SHOW);
   }
 }

--- a/lib/src/windows_single_instance.dart
+++ b/lib/src/windows_single_instance.dart
@@ -161,5 +161,6 @@ class WindowsSingleInstance {
     SetFocus(mhWnd);
     SetActiveWindow(mhWnd);
     AttachThreadInput(dwCurID, dwMyID, FALSE);
+    ShowWindow(mhWnd, SW_RESTORE);
   }
 }


### PR DESCRIPTION
Only if a window is not minimized, the api bringWindowToFront works as expected when set to 'true'.

After the fix, a minimized window is restored when bringWindowToFront = true.